### PR TITLE
PHP 8 compatibility and tihrd party libraries nonsense :derelict_house: 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,16 +10,17 @@
         "homepage": "https://github.com/facebook/facebook-instant-articles-sdk-php/contributors"
     }],
     "require": {
-        "php": "^5.4 || ^5.6 || ^7",
-        "symfony/css-selector": "^2.8 || ^3.1 || ^4.1",
-        "facebook/graph-sdk": "~5.0"
+        "php": "^5.4 || ^5.6 || ^7 || ^8",
+        "symfony/css-selector": "^2.8 || ^3.1 || ^4.1 || ^5.3",
+        "facebook/graph-sdk": "^5.0",
+        "fakerphp/faker": "^1.20",
+        "phpcompatibility/php-compatibility": "^9.3"
     },
     "require-dev": {
-        "fzaninotto/faker": "^1.6.0",
-        "phpunit/phpunit": "4.8.*",
-        "symfony/yaml": "2.1.* || 3.4.*",
-        "phpdocumentor/reflection-docblock": "^2.0 || ^4.0",
-        "squizlabs/php_codesniffer": "^2.6.0 || ^3.0.0"
+        "phpunit/phpunit": "^9.5",
+        "symfony/yaml": "2.1.* || 3.4.* || 5.4.*",
+        "squizlabs/php_codesniffer": "^2.6.0 || ^3.0.0",
+        "phpdocumentor/reflection-docblock": "^5.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "phpunit/phpunit": "^9.5",
         "symfony/yaml": "2.1.* || 3.4.* || 5.4.*",
         "squizlabs/php_codesniffer": "^2.6.0 || ^3.0.0",
-        "phpdocumentor/reflection-docblock": "^5.3"
+        "phpdocumentor/reflection-docblock": "^5.3",
+        "nickdnk/graph-sdk": "^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,15 @@
         "php": "^5.4 || ^5.6 || ^7 || ^8",
         "symfony/css-selector": "^2.8 || ^3.1 || ^4.1 || ^5.3",
         "facebook/graph-sdk": "^5.0",
-        "fakerphp/faker": "^1.20",
-        "phpcompatibility/php-compatibility": "^9.3"
+        "fakerphp/faker": "^1.20"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "symfony/yaml": "2.1.* || 3.4.* || 5.4.*",
         "squizlabs/php_codesniffer": "^2.6.0 || ^3.0.0",
         "phpdocumentor/reflection-docblock": "^5.3",
-        "nickdnk/graph-sdk": "^6.0"
+        "nickdnk/graph-sdk": "^6.0",
+        "phpcompatibility/php-compatibility": "^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,4 +5,5 @@
     <arg name="colors" />
     <arg value="sn" />
     <rule ref="PSR2"  />
+    <rule ref="./vendor/phpcompatibility/php-compatibility/PHPCompatibility"/>
 </ruleset>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,18 +1,17 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
-    bootstrap="vendor/autoload.php"
-    colors="true"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+        bootstrap="vendor/autoload.php" colors="true"
 >
-    <testsuites>
-        <testsuite name="Facebook InstantArticles SDK test suite">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory>./src</directory>
-        </whitelist>
-    </filter>
+  <coverage>
+    <include>
+      <directory>./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Facebook InstantArticles SDK test suite">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/Facebook/InstantArticles/Client/ClientTest.php
+++ b/tests/Facebook/InstantArticles/Client/ClientTest.php
@@ -19,7 +19,7 @@ class ClientTest extends TestCase
     private $article;
     private $facebook;
 
-    protected function setUp()
+    public function setUp(): void
     {
         $this->facebook = $this->getMockBuilder('Facebook\Facebook')
             ->disableOriginalConstructor()
@@ -135,23 +135,23 @@ class ClientTest extends TestCase
             ->willReturn($expectedSubmissionStatusID);
 
         $this->facebook
-            ->expects($this->at(0))
+            ->expects($this->exactly(2))
             ->method('post')
-            ->with('PAGE_ID' . Client::EDGE_NAME, [
-                'html_source' => $this->article->render(),
-                'published' => true,
-                'development_mode' => false,
-            ])
-            ->willReturn($serverResponseMock);
-
-        $this->facebook
-            ->expects($this->at(1))
-            ->method('post')
-            ->with('/', [
+            ->withConsecutive(
+              [
+                'PAGE_ID' . Client::EDGE_NAME, [
+                  'html_source' => $this->article->render(),
+                  'published' => true,
+                  'development_mode' => false,
+                ]
+              ],
+              [
+                '/', [
                 'id' => $this->article->getCanonicalURL(),
                 'scrape' => 'true',
-            ])
-            ->willReturn($serverResponseMock);
+                ]
+              ]
+            )->willReturn($serverResponseMock);
 
         $resultSubmissionStatusID = $this->client->importArticle($this->article, true, true);
         $this->assertEquals($expectedSubmissionStatusID, $resultSubmissionStatusID);
@@ -160,11 +160,11 @@ class ClientTest extends TestCase
     /**
      * Tests removing an article from an Instant Articles library.
      *
-     * @covers Facebook\InstantArticles\Client\Client::removeArticle()
+     * @covers \Facebook\InstantArticles\Client\Client::removeArticle()
      */
     public function testRemoveArticle()
     {
-        $canonicalURL = 'http://facebook.com';
+        $canonicalURL = 'https://facebook.com';
         $articleID = '1';
 
         // Use a mocked client with stubbed getArticleIDFromCanonicalURL().
@@ -792,7 +792,7 @@ class ClientTest extends TestCase
             ->with('PAGE_ID/claimed_urls?url=' .$url)
             ->willReturn($serverResponseMock);
 
-        $this->setExpectedException('\Facebook\InstantArticles\Client\ClientException');
+        $this->expectException('\Facebook\InstantArticles\Client\ClientException');
 
         $result = $this->client->claimURL($url);
     }
@@ -868,7 +868,7 @@ class ClientTest extends TestCase
             ->with('PAGE_ID/?instant_articles_submit_for_review=true')
             ->willReturn($serverResponseMock);
 
-        $this->setExpectedException('\Facebook\InstantArticles\Client\ClientException');
+        $this->expectException('\Facebook\InstantArticles\Client\ClientException');
 
         $result = $this->client->submitForReview();
     }

--- a/tests/Facebook/InstantArticles/Client/HelperTest.php
+++ b/tests/Facebook/InstantArticles/Client/HelperTest.php
@@ -16,7 +16,7 @@ class HelperTest extends TestCase
     private $helper;
     private $facebook;
 
-    protected function setUp()
+    public function setUp(): void
     {
         $this->facebook = $this->getMockBuilder('Facebook\Facebook')
             ->disableOriginalConstructor()

--- a/tests/Facebook/InstantArticles/Elements/InstantArticleTest.php
+++ b/tests/Facebook/InstantArticles/Elements/InstantArticleTest.php
@@ -16,7 +16,7 @@ class InstantArticleTest extends BaseHTMLTestCase
      * @var InstantArticle
      */
     private $article;
-    protected function setUp()
+    public function setUp(): void
     {
         date_default_timezone_set('UTC');
 

--- a/tests/Facebook/InstantArticles/Elements/TimeTest.php
+++ b/tests/Facebook/InstantArticles/Elements/TimeTest.php
@@ -14,7 +14,7 @@ class TimeTest extends BaseHTMLTestCase
 {
     private $timeDate;
 
-    protected function setUp()
+    public function setUp(): void
     {
         date_default_timezone_set('UTC');
         $this->timeDate = \DateTime::createFromFormat(

--- a/tests/Facebook/InstantArticles/Elements/Validators/InstantArticleValidatorTest.php
+++ b/tests/Facebook/InstantArticles/Elements/Validators/InstantArticleValidatorTest.php
@@ -127,6 +127,6 @@ class InstantArticleValidatorTest extends TestCase
         $warnings = array();
         InstantArticleValidator::getReport(array($footer), $warnings);
         $this->assertCount(1, $warnings);
-        $this->assertContains('Footer must have at least one of the', $warnings[0]->__toString());
+        $this->assertStringContainsString('Footer must have at least one of the', $warnings[0]->__toString());
     }
 }

--- a/tests/Facebook/InstantArticles/Elements/Validators/TypeTest.php
+++ b/tests/Facebook/InstantArticles/Elements/Validators/TypeTest.php
@@ -64,7 +64,7 @@ class TypeTest extends TestCase
 
     public function testIsNotInException()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         Type::enforce(
             Caption::create(),
@@ -85,7 +85,7 @@ class TypeTest extends TestCase
 
     public function testIsNotInEmptyException()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         Type::enforce(
             Caption::create(),
@@ -108,7 +108,7 @@ class TypeTest extends TestCase
 
     public function testIsNotInSetException()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         Type::enforce(
             Caption::create(),
@@ -144,7 +144,7 @@ class TypeTest extends TestCase
 
     public function testIsNotInInheritanceException()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         Type::enforce(
             AnimatedGIF::create(),
@@ -168,7 +168,7 @@ class TypeTest extends TestCase
 
     public function testIsNotStringException()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         Type::enforce(1, Type::STRING);
     }
@@ -220,7 +220,7 @@ class TypeTest extends TestCase
 
     public function testIsNotArrayInInheritanceException()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         Type::enforceArrayOf(
             [Image::create(), Video::create()],
@@ -263,7 +263,7 @@ class TypeTest extends TestCase
 
     public function testEnforceArrayMinSizeException()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         Type::enforceArraySizeGreaterThan([1,2,3], 4);
     }
@@ -288,7 +288,7 @@ class TypeTest extends TestCase
 
     public function testEnforceArrayMaxSizeException()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         Type::enforceArraySizeLowerThan([1,2,3], 2);
     }
@@ -330,7 +330,7 @@ class TypeTest extends TestCase
 
     public function testEnforceWithinExceptionString()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         Type::enforceWithin('a', ['x', 'y', 'z']);
     }
@@ -363,7 +363,7 @@ class TypeTest extends TestCase
     public function testEnforceElementTagFalse()
     {
         $document = new \DOMDocument();
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Type::enforceElementTag($document->createElement('body'), 'img');
     }
 

--- a/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Example/SimpleTransformerTest.php
@@ -61,7 +61,7 @@ class SimpleTransformerTest extends BaseHTMLTestCase
 
     public function testSelfTransformerContentMultipleAdsSettings()
     {
-        $this->setExpectedException(
+        $this->expectException(
             'Exception',
             'You must specify only one Ads Setting, either audience_network_placement_id or raw_html'
         );

--- a/tests/Facebook/InstantArticles/Transformer/Rules/RuleTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/Rules/RuleTest.php
@@ -14,7 +14,7 @@ class RuleTest extends TestCase
 {
     public function testCreateFromPropertiesThrowsException()
     {
-        $this->setExpectedException(
+        $this->expectException(
             'Exception',
             'All Rule class extensions should implement the Rule::createFrom($configuration) method'
         );
@@ -24,7 +24,7 @@ class RuleTest extends TestCase
 
     public function testCreateThrowsException()
     {
-        $this->setExpectedException(
+        $this->expectException(
             'Exception',
             'All Rule class extensions should implement the Rule::create() method'
         );


### PR DESCRIPTION
## The problem
When trying to migrate a Drupal project using `facebook/facebook-instant-articles-sdk-php` (through [fb_instant_articles](https://www.drupal.org/project/fb_instant_articles/issues/3300760) contrib module) to PHP 8, we found that neither this package nor its dependencies were PHP 8 compatible.

Unfortunately, this package seems to be a bit abandoned so there is not yet a release that supports PHP 8.

That's why I've created this fork :sparkles: 

Furthermore, all dependencies have PHP 8 ready versions, except for quite a _core_ package provided by the same Company: the `facebook/php-graph-sdk` was abandoned and... archived! (and no, no replacement is mentioned in the official pages that are still [pointing to the archived version](https://developers.facebook.com/docs/graph-api/guides/our-sdks/)). 

So after updating this library and the other maintained packages to its PHP 8 versions, we should find a way to either **replace** facebook php-graph-sdk with a working and hopefully better maintained package or... **fork** that repository (as well!) and apply the required changes to support PHP 8.

## This PR covers

* [x] Updates dependencies and php version in composer.json
* [x] Updates configuration files (phpunit and phpcs)
* [x] Updates tests (to work with the new phpunit version and remove deprecations)

## Left to-do
Either
- [ ] Try to replace the archived [facebook graph php sdk](https://github.com/facebookarchive/php-graph-sdk) with thephpleague [oauth2-facebook](https://github.com/thephpleague/oauth2-facebook) --> This will require major refactoring :S
- [x] Replace the archived Facebook graph sdk with one of these forks: https://github.com/brainexe/php-graph-sdk or https://github.com/nickdnk/php-graph-sdk --> This is not best practice, but would be the easier way.
- [ ] Fork the archived [facebook graph php sdk](https://github.com/facebookarchive/php-graph-sdk), apply the required changes, and finally use _that_ fork whithin _this_ fork :roll_eyes: 


Related to #.
Fixes #.
